### PR TITLE
Remove reference to ICRM on github page

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -11,8 +11,8 @@ nav_external_links:
   - title: Report an issue
     url: https://github.com/icrm-org/icrm-new/issues
 
-aux_links:
-  View ICRM on GitHub: https://github.com/icrm-org/icrm-new/
+#aux_links:
+#  View ICRM on GitHub: https://github.com/icrm-org/icrm-new/
 
 callouts:
   note:


### PR DESCRIPTION
remove link to https://github.com/icrm-new from upper righthand of pages.